### PR TITLE
refactor: use job parameter

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,13 +1,13 @@
 local M = {}
 
-function M:peek()
+function M:peek(job)
 	local child = Command("glow")
 		:args({
 			"--style",
 			"dark",
 			"--width",
-			tostring(self.area.w),
-			tostring(self.file.url),
+			tostring(job.area.w),
+			tostring(job.file.url),
 		})
 		:env("CLICOLOR_FORCE", "1")
 		:stdout(Command.PIPED)
@@ -15,36 +15,36 @@ function M:peek()
 		:spawn()
 
 	if not child then
-		return require("code").peek(self)
+		return require("code").peek(job)
 	end
 
-	local limit = self.area.h
+	local limit = job.area.h
 	local i, lines = 0, ""
 	repeat
 		local next, event = child:read_line()
 		if event == 1 then
-			return require("code").peek(self)
+			return require("code").peek(job)
 		elseif event ~= 0 then
 			break
 		end
 
 		i = i + 1
-		if i > self.skip then
+		if i > job.skip then
 			lines = lines .. next
 		end
-	until i >= self.skip + limit
+	until i >= job.skip + limit
 
 	child:start_kill()
-	if self.skip > 0 and i < self.skip + limit then
-		ya.manager_emit("peek", { math.max(0, i - limit), only_if = self.file.url, upper_bound = true })
+	if job.skip > 0 and i < job.skip + limit then
+		ya.manager_emit("peek", { math.max(0, i - limit), only_if = job.file.url, upper_bound = true })
 	else
 		lines = lines:gsub("\t", string.rep(" ", PREVIEW.tab_size))
-		ya.preview_widgets(self, { ui.Text.parse(lines):area(self.area) })
+		ya.preview_widgets(job, { ui.Text.parse(lines):area(job.area) })
 	end
 end
 
-function M:seek(units)
-	require("code").seek(self, units)
+function M:seek(job)
+	require("code").seek(job, job.units)
 end
 
 return M


### PR DESCRIPTION
This pull request includes changes to the `init.lua` file, focusing on refactoring the `peek` and `seek` methods to improve code readability and maintainability. The most important changes involve modifying method parameters and internal references to use a `job` object instead of `self`.

Refactoring methods:

* [`init.lua`](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L3-R47): Modified the `peek` method to take a `job` parameter and updated internal references from `self` to `job`.
* [`init.lua`](diffhunk://#diff-0fc5c43f6f1d7605fd7d16c088ba6b83f096eee8e2049517407bbaa27aa3a4f7L3-R47): Modified the `seek` method to take a `job` parameter and updated the method call to use the `job` object.